### PR TITLE
Fix typos

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -4,11 +4,11 @@ The shareholder extension provides a way to describe the shareholders of the ent
 
 Understanding the shareholders of the bidders or successful suppliers is important for analysis of the different organizations involved in contracting processes. This is particularly important where bidders are consortia.
 
-The extension introduces a new ```shareholder``` building block and extends the ```organization``` building block with a new ```shareholders``` field.
+The extension introduces a new ```Shareholder``` building block and extends the ```Organization``` building block with a new ```shareholders``` field.
 
 ## Shareholders Field
 
-The ```organization/shareholders``` field is an array of ```shareholder``` building blocks, describing the shareholders for the organization. 
+The ```Organization/shareholders``` field is an array of ```Shareholder``` building blocks, describing the shareholders for the organization. 
 
 ## Shareholder Building Block
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,7 @@ The shareholder building block provides a way to:
 
 * Link to the organization details of the shareholder
 * Describe the amount of shares held by the shareholder
-* Describe the voting rights assoicated with the shareholding
+* Describe the voting rights associated with the shareholding
 
 ```eval_rst
 .. extensiontable::

--- a/release-schema.json
+++ b/release-schema.json
@@ -69,7 +69,7 @@
         "beneficialOwnership":{
           "type":"object",
           "title":"Beneficial ownership",
-          "description":"This section can be used to record information concerning individuals or organisations with a beneficial ownership or control interests in this party. Where structured data is available, this section may be extended by embedding or linking to information modelled using the [Beneficial Ownership Data Standard (BODS)](https://github.com/openownership/data-standard).",
+          "description":"This section can be used to record information concerning individuals or organizations with a beneficial ownership or control interests in this party. Where structured data is available, this section may be extended by embedding or linking to information modelled using the [Beneficial Ownership Data Standard (BODS)](https://github.com/openownership/data-standard).",
           "properties":{
             "description":{
               "title":"Description",

--- a/versioned-release-validation-schema.json
+++ b/versioned-release-validation-schema.json
@@ -137,7 +137,7 @@
               "value": {
                 "type": "array",
                 "items": {
-                  "$ref": "#/definitions/shareholderUnversioned"
+                  "$ref": "#/definitions/ShareholderUnversioned"
                 },
                 "uniqueItems": true
               },
@@ -157,7 +157,7 @@
         "shareholders": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/shareholderUnversioned"
+            "$ref": "#/definitions/ShareholderUnversioned"
           },
           "uniqueItems": true
         }


### PR DESCRIPTION
I don't know how the incorrect casing of `shareholderUnversioned` got in, as I had been assuming `versioned-release-validation-schema.json` was autogenerated, but I can't find an uncapitalized version anywhere.