### PR TITLE
Fix codelists

Removing empty columns, leading and trailing whitespace, extra quoting characters, and/or adding missing quoting characters, closing newline

### DIFF
--- a/codelists/votingRights.csv
+++ b/codelists/votingRights.csv
@@ -1,6 +1,6 @@
-Category,Code,Title_en,Description_en,Source
-,ordinary,Ordinary voting rights,The shareholder is entitled to a single vote per share in all circumstances,
-,none,No voting rights,The shareholder is not entitled to vote under any circumstances,
-,restricted,Restricted voting rights,The shareholder is entitled to vote in specific circumstances only,
-,additional,Additional voting rights,The shareholder is entitled to more than one vote per share in all circumstances,
-,enhanced,Enhanced voting rights,The shareholder is entitled to more than one vote per share in specific circumstances only,
+Code,Title_en,Description_en
+ordinary,Ordinary voting rights,The shareholder is entitled to a single vote per share in all circumstances
+none,No voting rights,The shareholder is not entitled to vote under any circumstances
+restricted,Restricted voting rights,The shareholder is entitled to vote in specific circumstances only
+additional,Additional voting rights,The shareholder is entitled to more than one vote per share in all circumstances
+enhanced,Enhanced voting rights,The shareholder is entitled to more than one vote per share in specific circumstances only


### PR DESCRIPTION
open-contracting/standard-maintenance-scripts#6